### PR TITLE
feat: improve module exports for more atomic usages

### DIFF
--- a/src/functions/did/parse.ts
+++ b/src/functions/did/parse.ts
@@ -1,7 +1,7 @@
 import { UNSClient } from "../../clients/client";
 import { DIDHelpers, DIDTypes, DIDType } from "../../types/did";
 import { DidParserResult, DidParserError } from "./types";
-import { UNS_NFT_PROPERTY_KEY_REGEX } from "@uns/crypto";
+import { UNS_NFT_PROPERTY_KEY_REGEX } from "@uns/crypto/dist/constants";
 
 const TOKEN_PATTERN = /@?(unik:)?/;
 const TYPE_PATTERN = /((?:individual|organization|network|1|2|3):)?/;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 export * from "./clients";
 export * from "./functions";
 export * from "./types";
-export { getCurrentIAT, JwtUtils } from "./utils";
+export { getCurrentIAT } from "./utils";
+export * from "./utils/jwt-utils";
 
 // Please, do not re-export UNSConfig
 export { Network, DEFAULT_CLIENT_CONFIG } from "./config";

--- a/src/types/did.ts
+++ b/src/types/did.ts
@@ -1,1 +1,1 @@
-export { DIDHelpers, DIDTypes, DIDType } from "@uns/crypto";
+export { DIDHelpers, DIDTypes, DIDType } from "@uns/crypto/dist/models";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -36,7 +36,3 @@ export function computeRequestUrl(baseUrl: string, path: string, query?: string)
 export function getCurrentIAT() {
     return dayjs().unix();
 }
-
-import * as jwtUtils from "./jwt-utils";
-
-export const JwtUtils = jwtUtils;

--- a/src/utils/jwt-utils.ts
+++ b/src/utils/jwt-utils.ts
@@ -3,7 +3,7 @@ import { ec } from "elliptic";
 import { SimpleSigner, createJWT, verifyJWT, Signer, decodeJWT } from "did-jwt";
 
 import nanoid = require("nanoid");
-import { Identities } from "@uns/ark-crypto";
+import { Keys } from "@uns/ark-crypto/dist/identities/keys";
 import {
     NftFactoryServicesList,
     VoucherJWTPayload,
@@ -93,7 +93,7 @@ export async function createPropertyVerifierToken(
 
 async function createUnsJWT(jwtParams: JwtParams, payload: JWTPayload): Promise<string> {
     const curve = new ec("secp256k1");
-    const privateKey: string = Identities.Keys.fromPassphrase(jwtParams.issSecret).privateKey;
+    const privateKey: string = Keys.fromPassphrase(jwtParams.issSecret).privateKey;
     const keyPair: ec.KeyPair = curve.keyFromPrivate(privateKey);
     const signer: Signer = SimpleSigner(keyPair.getPrivate("hex"));
 


### PR DESCRIPTION
When you wanted to import just a simple function (or a type) from @uns/ts-sdk, it was importing all sort of packages.
Increasing size and risk of issues (in browser).
This commit refactors imports/exports to only strict use